### PR TITLE
Made local build script docker compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,13 +52,13 @@ bootstrap_rootfs()
 
 compress_rootfs()
 {
-    if [ -f "${ROOTFS_ARCHIVE}" ]; then
-        rm -f "${ROOTFS_ARCHIVE}"
+    if [ -f "${BUILD_DIR}/${ROOTFS_ARCHIVE}" ]; then
+        rm -f "${BUILD_DIR}/${ROOTFS_ARCHIVE}"
     fi
 
     echo "Compressing rootfs"
-    mksquashfs "${ROOTFS_DIR}" "${ROOTFS_ARCHIVE}" -comp xz
-    echo "Created ${ROOTFS_ARCHIVE}."
+    mksquashfs "${ROOTFS_DIR}" "${BUILD_DIR}/${ROOTFS_ARCHIVE}" -comp xz
+    echo "Created ${BUILD_DIR}/${ROOTFS_ARCHIVE}."
 }
 
 usage()

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -2,32 +2,69 @@
 
 set -eu
 
+CI_REGISTRY_IMAGE="${CI_REGISTRY_IMAGE:-registry.gitlab.com/ultimaker/embedded/platform/um-updatefs_armhf}"
+CI_REGISTRY_IMAGE_TAG="${CI_REGISTRY_IMAGE_TAG:-latest}"
+
 ARCH="${ARCH:-armhf}"
 CUR_DIR=$(pwd)
 BUILD_DIR="${CUR_DIR}/.build_${ARCH}"
-ROOTFS_IMG="${BUILD_DIR}/rootfs*.xz.img"
-RUN_ENV_CHECK="no"
-RUN_TESTS="no"
+ROOTFS_IMG="rootfs.xz.img"
+
+DOCKER_WORK_DIR="${DOCKER_WORK_DIR:-/build}"
+DOCKER_BUILD_DIR="${DOCKER_WORK_DIR}/.build_${ARCH}"
+
+run_env_check="no"
+run_tests="no"
+
+run_in_docker()
+{
+    work_dir="${1}"
+    script="${2}"
+    args="${3}"
+
+    docker run --rm \
+        --privileged \
+        -v "$(pwd):${DOCKER_WORK_DIR}" \
+        -w "${work_dir}" \
+        "${CI_REGISTRY_IMAGE}:${CI_REGISTRY_IMAGE_TAG}" \
+        "${script}" "${args}"
+}
 
 env_check()
 {
-    cd tests
-    ./buildenv.sh
-    cd "${CUR_DIR}"
+    if command -V docker; then
+        run_in_docker "${DOCKER_WORK_DIR}/tests" "./buildenv.sh" ""
+    else
+        ./tests/buildenv.sh
+    fi
+
+}
+
+run_build()
+{
+    env_check
+    if command -V docker; then
+        run_in_docker "${DOCKER_WORK_DIR}" "./build.sh" ""
+    else
+        ./build.sh
+    fi
 }
 
 run_tests()
 {
-    cd tests
-    ./rootfs.sh "${ROOTFS_IMG}"
-    cd "${CUR_DIR}"
+    env_check
+    if command -V docker; then
+        run_in_docker "${DOCKER_WORK_DIR}/tests" "./rootfs.sh" "${DOCKER_BUILD_DIR}/${ROOTFS_IMG}"
+    else
+        ./tests/rootfs.sh "${BUILD_DIR}/${ROOTFS_IMG}"
+    fi
 }
 
 usage()
 {
 cat <<-EOT
     Usage: ${0} [OPTIONS]
-        -c   Run build environment checks
+        -c   Run build environment checks (run by default when building and testing)
         -h   Print usage
         -t   Run rootfs tests
     NOTE: This script requires root permissions to run.
@@ -37,14 +74,14 @@ EOT
 while getopts ":cht" options; do
     case "${options}" in
     c)
-      RUN_ENV_CHECK="yes"
+      run_env_check="yes"
       ;;
     h)
       usage
       exit 0
       ;;
     t)
-      RUN_TESTS="yes"
+      run_tests="yes"
       ;;
     :)
       echo "Option -${OPTARG} requires an argument."
@@ -56,19 +93,20 @@ while getopts ":cht" options; do
       ;;
     esac
 done
-shift "((OPTIND - 1))"
+shift "$((OPTIND - 1))"
 
 
 # Check build environment requirements
-if [ "${RUN_ENV_CHECK}" = "yes" ]; then
+if [ "${run_env_check}" = "yes" ]; then
     env_check
+    exit 0
 fi
 
 # Build the rootfs image
-./build.sh
+run_build
 
 # Test the rootfs image
-if [ "${RUN_TESTS}" = "yes" ]; then
+if [ "${run_tests}" = "yes" ]; then
     run_tests
 fi
 


### PR DESCRIPTION
This means that when docker is installed the script is run in the given docker container, if not it will try locally.
Before the build or the test, the build environment preconditions are checked.

Constributes to: EMP-271, implements EMP-350

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>