### PR TITLE
Disable word-splitting check for PACKAGES

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,10 +81,14 @@ bootstrap_rootfs()
 
     mkdir -p "${ROOTFS_DIR}/etc/apk"
     echo "${ALPINE_REPO}/${ALPINE_VERSION}/main" > "${ROOTFS_DIR}/etc/apk/repositories"
+    
     # Install rootfs with base applications
+    # shellcheck disable=SC2086
+    # allow word splitting for ${PACKAGES}
     apk --root "${ROOTFS_DIR}" --update-cache \
        add --allow-untrusted --initdb --arch "${ARCH}" \
        ${PACKAGES}
+
     # Add baselayout etc files
     echo "Adding baselayout"
     apk --root "${ROOTFS_DIR}" \


### PR DESCRIPTION
This fixes the CI build failure on the linting stage.