### PR TITLE
buildenv: Add qemu to the buildenv test CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,15 @@ verify build environment:
   stage: verify
   <<: *environment_common
   script:
-  - docker run --privileged --rm -w /tests "$CI_COMMIT_SHA:$CI_PIPELINE_ID" ./buildenv.sh
+  - |
+    docker run \
+        --rm \
+        --privileged \
+        -e "ARM_EMU_BIN=${ARM_EMU_BIN}" \
+        -v "${ARM_EMU_BIN}:${ARM_EMU_BIN}:ro" \
+        -w /tests \
+        "$CI_COMMIT_SHA:$CI_PIPELINE_ID" \
+        sh -x ./buildenv.sh
 
 push build environment:
   <<: *environment_common


### PR DESCRIPTION
To be able to run arm emulated code, two things are required. The
QEMU_EMU_BIN variable needs to be populated with the path to the local
arm emulator, and this binary needs to be mounted into the container.

The build_for_ultimaker.sh script already does this, the CI did not.

Addresses issue EMP-272, fixes EMP-371.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>