### PR TITLE
EMP-378 Format partitions to honor the new disk size.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ ALPINE_REPO="${ALPINE_REPO:-http://dl-cdn.alpinelinux.org/alpine}"
 TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-um-update_toolbox.xz.img}"
 ROOTFS_DIR="${BUILD_DIR}/rootfs"
 
-COMMANDS="busybox e2fsprogs-extra f2fs-tools rsync sfdisk"
+COMMANDS="blkid busybox e2fsprogs-extra f2fs-tools rsync sfdisk"
 
 cleanup()
 {

--- a/test/buildenv.sh
+++ b/test/buildenv.sh
@@ -6,7 +6,7 @@ ARM_EMU_BIN="${ARM_EMU_BIN:-}"
 BINFMT_MISC="${BINFMT_MISC:-/proc/sys/fs/binfmt_misc/}"
 
 FILESYSTEMS="ext4 f2fs overlay squashfs tmpfs"
-COMMANDS="apk losetup mkfs.ext4 mkfs.f2fs mksquashfs sed sfdisk xz"
+COMMANDS="apk blkid fsck.ext4 fsck.f2fs losetup mkfs.ext4 mkfs.f2fs mksquashfs sed sfdisk xz"
 
 ARMv7_MAGIC="7f454c4601010100000000000000000002002800"
 


### PR DESCRIPTION
Add a function that checks the partition layout and resizes partitions
where needed or reformats them if resize is not possible.

This pulls in blkid as we need to identify the partition type to be
able to call the correct tools.

This script does make the assumption that all partitions are f2fs
based, except for the BOOT partition, which is ext4 until u-boot
supports f2fs.

Addresses EMP-272, closes EMP-378

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>