### PR TITLE
local-build: Always pull build environment in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ By default the build script runs an environment check, builds the image and then
 During the initramfs routine (executed between 2st stage U-boot and 3th stage Linux debian load) this toolbox image mounted and the executable entryscript '/sbin/startup.sh' will be executed. This script shall be used to execute any required routine. Very important here is to make sure all required resources are nicely cleaned up and errors are properly handled, not to bring the system in an unrecoverable state. 
 
 ## Updating the docker image in the docker registry
-We only want to update the docker image when required and we only want to do this after quality checks and when merged to master. Therefore Docker container changes should be tested locally first. Build a container locally and pass it to the build script. 
+We only want to update the docker image when required and we only want to do this after quality checks and when merged to master. Therefore Docker container changes should be tested locally first. To build a container locally all is needed to pass the name of the request image to the build script, and it will try to pull the image (which will fail) and build and run with the local image instead.
 ```sh
-> docker build -t local_test_image_name .
 > CI_REGISTRY_IMAGE="local_test_image_name" ./build_for_ultimaker.sh
 ```
 To make the changes available in the Docker repository follow the instruction as described on the confluence [CI/CD](https://confluence.ultimaker.com:8443/pages/viewpage.action?pageId=12431561) page.

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -31,6 +31,14 @@ cleanup()
     unset ARM_EMU_BIN
 }
 
+update_docker_image()
+{
+    if ! docker pull "${CI_REGISTRY_IMAGE}:${CI_REGISTRY_IMAGE_TAG}" 2> /dev/null; then
+        echo "Unable to update docker image '${CI_REGISTRY_IMAGE}:${CI_REGISTRY_IMAGE_TAG}', building locally instead."
+        docker build . -t "${CI_REGISTRY_IMAGE}:${CI_REGISTRY_IMAGE_TAG}"
+    fi
+}
+
 setup_emulation_support()
 {
     for emu in /proc/sys/fs/binfmt_misc/*; do
@@ -134,6 +142,10 @@ done
 shift "$((OPTIND - 1))"
 
 setup_emulation_support
+
+if command -V docker; then
+    update_docker_image
+fi
 
 if [ "${run_env_check}" = "yes" ]; then
     env_check


### PR DESCRIPTION
When using docker run, it will only pull the latest image if it does
not exist yet. To ensure we always have the latest image, we need to
run docker pull. However that interferes with the development approach,
where we need a newer (modified) image, that we haven't pushed yet (and
shouldn't).

This patch first tries to pull the image, and if that fails, builds it
locally instead using the supplied tag name.

Address EMP-272, closes EMP-393.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>